### PR TITLE
TypeScript: export default

### DIFF
--- a/data/random-teams.js
+++ b/data/random-teams.js
@@ -1,7 +1,7 @@
 'use strict';
 
-/** @type {typeof import('../sim/dex')} */
-const Dex = require(/** @type {any} */ ('../.sim-dist/dex'));
+/** @type {typeof import('../sim/dex').Dex} */
+const Dex = require(/** @type {any} */ ('../.sim-dist/dex')).Dex;
 /** @type {typeof import('../sim/prng').PRNG} */
 const PRNG = require(/** @type {any} */ ('../.sim-dist/prng')).PRNG;
 

--- a/lib/crashlogger.ts
+++ b/lib/crashlogger.ts
@@ -22,7 +22,7 @@ let transport: any;
  * Logs when a crash happens to console, then e-mails those who are configured
  * to receive them.
  */
-export = function crashlogger(
+export function crashlogger(
 	error: Error | string, description: string, data: AnyObject | null = null
 ): string | null {
 	const datenow = Date.now();
@@ -88,4 +88,6 @@ export = function crashlogger(
 	}
 
 	return null;
-};
+}
+
+export default crashlogger;

--- a/lib/dashycode.ts
+++ b/lib/dashycode.ts
@@ -314,3 +314,9 @@ export function vizStream(codeBuf: string, translate: boolean = true) {
 	}
 	return spacedStream;
 }
+
+export default {
+	encode,
+	decode,
+	vizStream,
+};

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -432,3 +432,5 @@ function getFs(path: string) {
 export const FS = Object.assign(getFs, {
 	FileReadStream,
 });
+
+export default FS;

--- a/lib/process-manager.ts
+++ b/lib/process-manager.ts
@@ -18,7 +18,7 @@ const ROOT_DIR = path.resolve(__dirname, '..');
 export const processManagers: ProcessManager[] = [];
 export const disabled = false;
 
-class SubprocessStream extends Streams.ObjectReadWriteStream<string> {
+export class SubprocessStream extends Streams.ObjectReadWriteStream<string> {
 	constructor(public process: ChildProcess, public taskId: number) {
 		super();
 		this.process = process;

--- a/lib/repl.ts
+++ b/lib/repl.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import * as net from 'net';
 import * as path from 'path';
 import * as repl from 'repl';
+import crashlogger from './crashlogger';
 
 export const Repl = new class {
 	/**
@@ -101,12 +102,12 @@ export const Repl = new class {
 				// tslint:disable-next-line:variable-name
 				fs.unlink(pathname, _err => {
 					if (_err && _err.code !== "ENOENT") {
-						require('./crashlogger')(_err, `REPL: ${filename}`);
+						crashlogger(_err, `REPL: ${filename}`);
 					}
 					server.close();
 				});
 			} else {
-				require('./crashlogger')(err, `REPL: ${filename}`);
+				crashlogger(err, `REPL: ${filename}`);
 				server.close();
 			}
 		});
@@ -117,3 +118,5 @@ export const Repl = new class {
 		});
 	}
 };
+
+export default Repl;

--- a/lib/streams.ts
+++ b/lib/streams.ts
@@ -751,3 +751,15 @@ export class ObjectReadWriteStream<T> extends ObjectReadStream<T> implements Obj
 export function readAll(nodeStream: NodeJS.ReadableStream, encoding?: any) {
 	return new ReadStream(nodeStream).readAll(encoding);
 }
+
+export const Streams = {
+	ReadStream,
+	WriteStream,
+	ReadWriteStream,
+	ObjectReadStream,
+	ObjectWriteStream,
+	ObjectReadWriteStream,
+	readAll,
+};
+
+export default Streams;

--- a/pokemon-showdown
+++ b/pokemon-showdown
@@ -92,7 +92,7 @@ if (!process.argv[2] || /^[0-9]+$/.test(process.argv[2])) {
 		}
 	case 'generate-team':
 		{
-			var Dex = require('./.sim-dist/dex');
+			var Dex = require('./.sim-dist/dex').Dex;
 			global.toID = Dex.getId;
 			var seed = process.argv[4] ? process.argv[4].split(',').map(Number) : undefined;
 			console.log(Dex.packTeam(Dex.generateTeam(process.argv[3], {seed})));
@@ -100,7 +100,7 @@ if (!process.argv[2] || /^[0-9]+$/.test(process.argv[2])) {
 		break;
 	case 'validate-team':
 		{
-			var Dex = require('./.sim-dist/dex');
+			var Dex = require('./.sim-dist/dex').Dex;
 			var TeamValidator = require('./.sim-dist/team-validator');
 			var validator = TeamValidator(process.argv[3]);
 			var Streams = require('./.lib-dist/streams');
@@ -139,7 +139,7 @@ if (!process.argv[2] || /^[0-9]+$/.test(process.argv[2])) {
 		break;
 	case 'unpack-team':
 		{
-			var Dex = require('./.sim-dist/dex');
+			var Dex = require('./.sim-dist/dex').Dex;
 			var Streams = require('./.lib-dist/streams');
 			var stdin = new Streams.ReadStream(process.stdin);
 
@@ -157,7 +157,7 @@ if (!process.argv[2] || /^[0-9]+$/.test(process.argv[2])) {
 		break;
 	case 'pack-team':
 		{
-			var Dex = require('./.sim-dist/dex');
+			var Dex = require('./.sim-dist/dex').Dex;
 			var Streams = require('./.lib-dist/streams');
 			var stdin = new Streams.ReadStream(process.stdin);
 

--- a/server/chat-commands.js
+++ b/server/chat-commands.js
@@ -3016,7 +3016,7 @@ const commands = {
 				Chat.uncacheDir('./data');
 				Chat.uncache('./config/formats');
 				// reload .sim-dist/dex.js
-				global.Dex = require('../.sim-dist/dex');
+				global.Dex = require('../.sim-dist/dex').Dex;
 				// rebuild the formats list
 				delete Rooms.global.formatList;
 				// respawn validator processes
@@ -3030,7 +3030,7 @@ const commands = {
 			} else if (target === 'loginserver') {
 				FS('config/custom.css').unwatch();
 				Chat.uncache('./server/loginserver');
-				global.LoginServer = require('./loginserver');
+				global.LoginServer = require('./loginserver').LoginServer;
 				this.sendReply("The login server has been hot-patched. New login server requests will use the new code.");
 			} else if (target === 'learnsets' || target === 'validator') {
 				if (lock['validator']) return this.errorReply(`Hot-patching the validator has been disabled by ${lock['validator'].by} (${lock['validator'].reason})`);

--- a/server/chat-formatter.ts
+++ b/server/chat-formatter.ts
@@ -444,3 +444,5 @@ class TextFormatter {
 export function formatText(str: string, isTrusted = false) {
 	return new TextFormatter(str, isTrusted).get();
 }
+
+export default formatText;

--- a/server/chat-plugins/datasearch.js
+++ b/server/chat-plugins/datasearch.js
@@ -1702,7 +1702,7 @@ if (!PM.isParentProcess) {
 		});
 	}
 
-	global.Dex = require('../../.sim-dist/dex');
+	global.Dex = require('../../.sim-dist/dex').Dex;
 	global.toID = Dex.getId;
 	Dex.includeData();
 	global.TeamValidator = require('../../.sim-dist/team-validator').TeamValidator;

--- a/server/chat-plugins/modlog.js
+++ b/server/chat-plugins/modlog.js
@@ -615,7 +615,7 @@ if (!PM.isParentProcess) {
 			Monitor.crashlog(err, 'A modlog child process');
 		}
 	});
-	global.Dex = require('../../.sim-dist/dex');
+	global.Dex = require('../../.sim-dist/dex').Dex;
 	global.toID = Dex.getId;
 
 	require('../../.lib-dist/repl').Repl.start('modlog', cmd => eval(cmd));

--- a/server/global.d.ts
+++ b/server/global.d.ts
@@ -2,7 +2,7 @@ import child_process = require('child_process');
 
 import RoomsType = require('./rooms');
 import RoomlogsType = require('./roomlogs');
-import LadderStoreType = require('./ladders-remote');
+import LadderStoreType from './ladders-remote';
 import LaddersType = require('./ladders');
 import UsersType = require('./users');
 import PunishmentsType = require('./punishments');

--- a/server/globals.ts
+++ b/server/globals.ts
@@ -7,7 +7,7 @@ declare let Config: {[k: string]: any};
 
 declare let Monitor: typeof import('./monitor');
 
-declare let LoginServer: typeof import('./loginserver');
+declare let LoginServer: typeof import('./loginserver').LoginServer;
 
 // type RoomBattle = AnyObject;
 

--- a/server/index.js
+++ b/server/index.js
@@ -88,10 +88,10 @@ if (Config.watchconfig) {
  * Set up most of our globals
  *********************************************************/
 
-global.Dex = require('../.sim-dist/dex');
+global.Dex = require('../.sim-dist/dex').Dex;
 global.toID = Dex.getId;
 
-global.LoginServer = require('../.server-dist/loginserver');
+global.LoginServer = require('../.server-dist/loginserver').LoginServer;
 
 global.Ladders = require('./ladders');
 

--- a/server/ip-tools.ts
+++ b/server/ip-tools.ts
@@ -19,7 +19,7 @@
 const BLOCKLISTS = ['sbl.spamhaus.org', 'rbl.efnetrbl.org'];
 
 import * as dns from 'dns';
-import {FS} from '../lib/fs';
+import FS from '../lib/fs';
 
 export const IPTools = new class {
 	dnsblCache = new Map<string, string | null>([

--- a/server/ladders-local.ts
+++ b/server/ladders-local.ts
@@ -15,7 +15,7 @@
 
 'use strict';
 
-import {FS} from '../lib/fs';
+import FS from '../lib/fs';
 
 // ladderCaches = {formatid: ladder OR Promise(ladder)}
 // Use Ladders(formatid).ladder to guarantee a Promise(ladder).
@@ -28,7 +28,7 @@ type LadderCache = Map<string, LadderRow[] | Promise<LadderRow[]>>;
 
 const ladderCaches: LadderCache = new Map();
 
-class LadderStore {
+export class LadderStore {
 	formatid: string;
 	ladder: LadderRow[] | null;
 	ladderPromise: Promise<LadderRow[]> | null;
@@ -338,4 +338,4 @@ class LadderStore {
 	}
 }
 
-export = LadderStore;
+export default LadderStore;

--- a/server/ladders-remote.ts
+++ b/server/ladders-remote.ts
@@ -14,7 +14,7 @@
 
 'use strict';
 
-class LadderStore {
+export class LadderStore {
 	formatid: string;
 	static formatsListPrefix = '';
 
@@ -143,4 +143,4 @@ class LadderStore {
 	}
 }
 
-export = LadderStore;
+export default LadderStore;

--- a/server/ladders.js
+++ b/server/ladders.js
@@ -11,7 +11,7 @@
 'use strict';
 
 /** @type {typeof LadderStoreT} */
-const LadderStore = require(typeof Config === 'object' && Config.remoteladder ? '../.server-dist/ladders-remote' : '../.server-dist/ladders-local');
+const LadderStore = require(typeof Config === 'object' && Config.remoteladder ? '../.server-dist/ladders-remote' : '../.server-dist/ladders-local').LadderStore;
 
 const SECONDS = 1000;
 const PERIODIC_MATCH_INTERVAL = 60 * SECONDS;

--- a/server/loginserver.ts
+++ b/server/loginserver.ts
@@ -16,8 +16,8 @@ const LOGIN_SERVER_BATCH_TIME = 1000;
 const http = Config.loginserver.startsWith('http:') ? require('http') : require('https');
 import * as url from 'url';
 
-import {FS} from '../lib/fs';
-import * as Streams from '../lib/streams';
+import FS from '../lib/fs';
+import Streams from '../lib/streams';
 
 /**
  * A custom error type used when requests to the login server take too long.
@@ -224,7 +224,7 @@ class LoginServerInstance {
 	}
 }
 
-const LoginServer = Object.assign(new LoginServerInstance(), {
+export const LoginServer = Object.assign(new LoginServerInstance(), {
 	TimeoutError,
 
 	ladderupdateServer: new LoginServerInstance(),
@@ -240,4 +240,4 @@ if (!Config.nofswriting) {
 	LoginServer.request('invalidatecss');
 }
 
-export = LoginServer;
+export default LoginServer;

--- a/server/monitor.js
+++ b/server/monitor.js
@@ -55,8 +55,8 @@ if (('Config' in global) &&
 	Config.loglevel = 2;
 }
 
-/** @type {typeof import('../lib/crashlogger')} */
-let crashlogger = require(/** @type {any} */('../.lib-dist/crashlogger'));
+/** @type {typeof import('../lib/crashlogger').crashlogger} */
+let crashlogger = require(/** @type {any} */('../.lib-dist/crashlogger')).crashlogger;
 
 const Monitor = module.exports = {
 	/*********************************************************

--- a/server/sockets.js
+++ b/server/sockets.js
@@ -23,7 +23,7 @@ const FS = require(/** @type {any} */('../.lib-dist/fs')).FS;
 /** @typedef {0 | 1 | 2 | 3 | 4} ChannelID */
 
 const Monitor = {
-	crashlog: require(/** @type {any} */('../.lib-dist/crashlogger')),
+	crashlog: require(/** @type {any} */('../.lib-dist/crashlogger')).crashlogger,
 };
 
 if (cluster.isMaster) {

--- a/server/team-validator-async.js
+++ b/server/team-validator-async.js
@@ -45,7 +45,7 @@ const PM = new QueryProcessManager(module, async message => {
 	try {
 		problems = TeamValidator(formatid).validateTeam(parsedTeam, removeNicknames);
 	} catch (err) {
-		require(/** @type {any} */('../.lib-dist/crashlogger'))(err, 'A team validation', {
+		require(/** @type {any} */('../.lib-dist/crashlogger')).crashlogger(err, 'A team validation', {
 			formatid: formatid,
 			team: team,
 		});
@@ -92,7 +92,7 @@ if (!PM.isParentProcess) {
 		});
 	}
 
-	global.Dex = require(/** @type {any} */ ('../.sim-dist/dex')).includeData();
+	global.Dex = require(/** @type {any} */ ('../.sim-dist/dex')).Dex.includeData();
 	global.toID = Dex.getId;
 	global.Chat = require('./chat');
 

--- a/sim/battle-stream.ts
+++ b/sim/battle-stream.ts
@@ -266,3 +266,5 @@ export class BattleTextStream extends Streams.ReadWriteStream {
 		return this.battleStream.end();
 	}
 }
+
+export default BattleStream;

--- a/sim/battle.ts
+++ b/sim/battle.ts
@@ -4,14 +4,14 @@
  *
  * @license MIT
  */
-import Dex = require('./dex');
+import Dex from './dex';
 global.toID = Dex.getId;
 import * as Data from './dex-data';
-import {Field} from './field';
-import {Pokemon} from './pokemon';
+import Field from './field';
+import Pokemon from './pokemon';
 import {PRNG, PRNGSeed} from './prng';
-import {Side} from './side';
-import {State} from './state';
+import Side from './side';
+import State from './state';
 
 /** A Pokemon that has fainted. */
 interface FaintedPokemon {
@@ -3268,3 +3268,5 @@ class UnimplementedError extends Error {
 		this.name = 'UnimplementedError';
 	}
 }
+
+export default Battle;

--- a/sim/dex.ts
+++ b/sim/dex.ts
@@ -129,7 +129,7 @@ const BattleNatures: {[k: string]: Nature} = {
 
 const toID = Data.Tools.getId;
 
-class ModdedDex {
+export class ModdedDex {
 	readonly Data: typeof Data;
 	readonly ModdedDex: typeof ModdedDex;
 
@@ -1486,4 +1486,5 @@ dexes['base'] = new ModdedDex(undefined, true);
 // "gen7" is an alias for the current base data
 dexes['gen7'] = dexes['base'];
 
-export = dexes['gen7'];
+export const Dex = dexes['gen7'];
+export default Dex;

--- a/sim/examples/battle-stream-example.ts
+++ b/sim/examples/battle-stream-example.ts
@@ -10,8 +10,8 @@
  */
 
 import {BattleStream, getPlayerStreams} from '../battle-stream';
-import Dex = require('../dex');
-import {RandomPlayerAI} from '../tools/random-player-ai';
+import Dex from '../dex';
+import RandomPlayerAI from '../tools/random-player-ai';
 
 /*********************************************************************
  * Run AI

--- a/sim/field.ts
+++ b/sim/field.ts
@@ -5,7 +5,7 @@
  * @license MIT
  */
 
-import {State} from './state';
+import State from './state';
 
 export class Field {
 	readonly battle: Battle;
@@ -228,3 +228,5 @@ export class Field {
 		this.battle = null!;
 	}
 }
+
+export default Field;

--- a/sim/global.d.ts
+++ b/sim/global.d.ts
@@ -1,8 +1,8 @@
 import {Battle as BattleType} from './battle';
 import * as BattleStreamType from './battle-stream';
 import * as DataType from './dex-data';
-import DexType = require('./dex');
-import SimType = require('./index');
+import DexType from './dex';
+import SimType from './index';
 import {Field as FieldType} from './field';
 import {Pokemon as PokemonType} from './pokemon';
 import {PRNG as PRNGType} from './prng';
@@ -22,7 +22,7 @@ declare global {
 	const BattleStream: BattleStreamType.BattleStream
 	const Dex: typeof DexType
 	const Field: FieldType
-	const ModdedDex: typeof DexType
+	const ModdedDex: typeof DexType.ModdedDex
 	const PRNG: PRNGType
 	const Pokemon: PokemonType
 	const Side: SideType

--- a/sim/globals.ts
+++ b/sim/globals.ts
@@ -1,6 +1,6 @@
 type Battle = import('./battle').Battle
 type Field = import('./field').Field
-type ModdedDex = typeof import('./dex')
+type ModdedDex = import('./dex').ModdedDex
 type Pokemon = import('./pokemon').Pokemon
 type PRNGSeed = import('./prng').PRNGSeed;
 type Side = import('./side').Side

--- a/sim/index.ts
+++ b/sim/index.ts
@@ -9,13 +9,13 @@
  *
  * @license MIT license
  */
-import {Battle} from './battle';
-import {BattleStream} from './battle-stream';
-import Dex = require('./dex');
-import {Pokemon} from './pokemon';
-import {PRNG} from './prng';
-import {Side} from './side';
-import {TeamValidator} from './team-validator';
+import Battle from './battle';
+import BattleStream from './battle-stream';
+import Dex from './dex';
+import Pokemon from './pokemon';
+import PRNG from './prng';
+import Side from './side';
+import TeamValidator from './team-validator';
 
 export {
 	Pokemon,
@@ -27,3 +27,16 @@ export {
 
 	BattleStream,
 };
+
+export const Sim = {
+	Pokemon,
+	Side,
+	Battle,
+	PRNG,
+	Dex,
+	TeamValidator,
+
+	BattleStream,
+};
+
+export default Sim;

--- a/sim/pokemon.ts
+++ b/sim/pokemon.ts
@@ -5,7 +5,7 @@
  * @license MIT license
  */
 
-import {State} from './state';
+import State from './state';
 
  /** A Pokemon's move slot. */
 interface MoveSlot {
@@ -1712,3 +1712,5 @@ export class Pokemon {
 		this.side = null!;
 	}
 }
+
+export default Pokemon;

--- a/sim/prng.ts
+++ b/sim/prng.ts
@@ -227,3 +227,5 @@ random(m: number, n: number) {
 	return (m ? (n ? (result % (n - m)) + m : result % m) : result / 0x10000)
 }
 */
+
+export default PRNG;

--- a/sim/side.ts
+++ b/sim/side.ts
@@ -5,8 +5,8 @@
  * @license MIT license
  */
 import {RequestState} from './battle';
-import {Pokemon} from './pokemon';
-import {State} from './state';
+import Pokemon from './pokemon';
+import State from './state';
 
 /** A single action that can be chosen. */
 interface ChosenAction {
@@ -899,3 +899,5 @@ export class Side {
 		this.foe = null!;
 	}
 }
+
+export default Side;

--- a/sim/state.ts
+++ b/sim/state.ts
@@ -5,12 +5,12 @@
  * @license MIT
  */
 
-import {Battle} from './battle';
-import Dex = require('./dex');
+import Battle from './battle';
+import Dex from './dex';
 import * as Data from './dex-data';
-import {Field} from './field';
-import {Pokemon} from './pokemon';
-import {PRNG} from './prng';
+import Field from './field';
+import Pokemon from './pokemon';
+import PRNG from './prng';
 import {Choice, Side} from './side';
 
 // The simulator supports up to 24 different Pokemon on a team. Serialization
@@ -413,3 +413,5 @@ export const State = new class {
 		}
 	}
 };
+
+export default State;

--- a/sim/team-validator.ts
+++ b/sim/team-validator.ts
@@ -7,7 +7,7 @@
  * @license MIT
  */
 
-import Dex = require('./dex');
+import Dex from './dex';
 
 export class Validator {
 	readonly format: Format;
@@ -1305,3 +1305,5 @@ function getValidator(format: string | Format) {
 export const TeamValidator = Object.assign(getValidator, {
 	Validator,
 });
+
+export default TeamValidator;

--- a/sim/tools/exhaustive-runner.ts
+++ b/sim/tools/exhaustive-runner.ts
@@ -6,9 +6,9 @@
  */
 
 import {ObjectReadWriteStream} from '../../lib/streams';
-import Dex = require('../dex');
+import Dex from '../dex';
 import {PRNG, PRNGSeed} from '../prng';
-import {RandomPlayerAI} from './random-player-ai';
+import RandomPlayerAI from './random-player-ai';
 import {AIOptions, Runner} from './runner';
 const toID = Dex.getId;
 
@@ -447,3 +447,5 @@ class CoordinatedPlayerAI extends RandomPlayerAI {
 		return id;
 	}
 }
+
+export default ExhaustiveRunner;

--- a/sim/tools/multi-random-runner.ts
+++ b/sim/tools/multi-random-runner.ts
@@ -108,3 +108,5 @@ export class MultiRandomRunner {
 		return false;
 	}
 }
+
+export default MultiRandomRunner;

--- a/sim/tools/random-player-ai.ts
+++ b/sim/tools/random-player-ai.ts
@@ -181,3 +181,5 @@ export class RandomPlayerAI extends BattlePlayer {
 		return this.prng.sample(switches).slot;
 	}
 }
+
+export default RandomPlayerAI;

--- a/sim/tools/runner.ts
+++ b/sim/tools/runner.ts
@@ -9,10 +9,10 @@ import assert = require('assert');
 import fs = require('fs');
 
 import {ObjectReadWriteStream} from '../../lib/streams';
-import {Battle} from '../battle';
+import Battle from '../battle';
 import * as BattleStreams from '../battle-stream';
 import {PRNG, PRNGSeed} from '../prng';
-import {RandomPlayerAI} from './random-player-ai';
+import RandomPlayerAI from './random-player-ai';
 
 export interface AIOptions {
 	createAI: (stream: ObjectReadWriteStream<string>, options: AIOptions) => RandomPlayerAI;
@@ -204,3 +204,5 @@ class DualStream {
 		this.test.battle.restart(send);
 	}
 }
+
+export default Runner;

--- a/test/common.js
+++ b/test/common.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const Dex = require('./../.sim-dist/dex');
+const Dex = require('./../.sim-dist/dex').Dex;
 const Sim = require('./../.sim-dist');
 
 const cache = new Map();

--- a/test/sim/dex.js
+++ b/test/sim/dex.js
@@ -6,13 +6,13 @@ describe('Mod loader', function () {
 	it.skip('should work fine in any order', function () {
 		{
 			Chat.uncacheTree('./.sim-dist/dex');
-			let Dex = require('./../../../.sim-dist/dex');
+			let Dex = require('./../../../.sim-dist/dex').Dex;
 			assert.strictEqual(Dex.mod('gen2').getTemplate('nidoking').learnset.bubblebeam.join(','), '1M');
 			assert.strictEqual(Dex.mod('gen2').getMove('crunch').secondaries[0].boosts.def, undefined);
 		}
 		{
 			Chat.uncacheTree('./.sim-dist/dex');
-			let Dex = require('./../../../.sim-dist/dex');
+			let Dex = require('./../../../.sim-dist/dex').Dex;
 			Dex.mod('gen2').getTemplate('nidoking');
 			Dex.mod('gen4').getMove('crunch');
 			assert.strictEqual(Dex.mod('gen2').getTemplate('nidoking').learnset.bubblebeam.join(','), '1M');

--- a/tools/simulate.js
+++ b/tools/simulate.js
@@ -41,7 +41,7 @@ const path = require('path');
 const shell = cmd => child_process.execSync(cmd, {stdio: 'inherit', cwd: path.resolve(__dirname, '..')});
 shell('node build');
 
-const Dex = require('../.sim-dist/dex');
+const Dex = require('../.sim-dist/dex').Dex;
 Dex.includeModData();
 
 const {ExhaustiveRunner} = require('../.sim-dist/tools/exhaustive-runner');


### PR DESCRIPTION
I'm currently pretty annoyed at TypeScript and TC39 for default exports
being a mess.

The goal here is to be able to type

    import Dex from './dex';

instead of any of

    import Dex = require('./dex');
    import {Dex} from './dex';
    import * as Dex from './dex';

This part involves a significant amount of struggle.

First, you can't automatically package up all your exports as your
default export. This leads to extremely un-DRY code, like in sim/index:

    export {
        Pokemon,
        Side,
        Battle,
        PRNG,
        Dex,
        TeamValidator,

        BattleStream,
    };

    export const Sim = {
        Pokemon,
        Side,
        Battle,
        PRNG,
        Dex,
        TeamValidator,

        BattleStream,
    };

(Both of these exports would be entirely unnecessary if you could just
automatically declare the file's exports as a default namespace.)

Second, a default export can't easily be a namespace. And TypeScript
doesn't allow types to exist in objects. Take the example from earlier:

    export const Sim = {
        Pokemon,
    };

If we were to try to use it:

    import Sim from './sim';
    let pokemon: Sim.Pokemon;

you'll get this error:

    Cannot find namespace 'Sim'. ts(2503)

You can, of course, fix this by making Sim a namespace:

    const PokemonT = Pokemon;
    type PokemonT = Pokemon;
    export namespace Sim {
        export const Pokemon = PokemonT;
        type Pokemon = PokemonT;
    }

But this quickly gets ridiculous the more classes you try to export.

You'd think there'd be a better way to do this. But I, at least,
haven't found one.